### PR TITLE
identity.subscription_status_path supports minimum_consent_level

### DIFF
--- a/lib/tokyo_api/identity.rb
+++ b/lib/tokyo_api/identity.rb
@@ -17,8 +17,14 @@ module TokyoApi
       path
     end
 
-    def subscription_status_path(id, opt_in_external_id:)
+    def subscription_status_path(id, opt_in_external_id:, minimum_consent_level: nil)
       path = "/#{normalized_base_path}subscription_status/#{url_escape(id)}?opt_in_external_id=#{url_escape(opt_in_external_id)}"
+
+      if minimum_consent_level
+        path = "#{path}&minimum_consent_level=#{url_escape(minimum_consent_level)}"
+      end
+
+      path
     end
   end
 end

--- a/spec/identity_spec.rb
+++ b/spec/identity_spec.rb
@@ -60,5 +60,10 @@ describe TokyoApi::Identity do
       expected_path = '/identity/subscription_status/abc123?opt_in_external_id=policy-1.5'
       expect(subject.identity.subscription_status_path('abc123', opt_in_external_id: 'policy-1.5')).to eq expected_path
     end
+
+    it 'should support minimum_consent_level' do
+      expected_path = '/identity/subscription_status/abc123?opt_in_external_id=policy-1.5&minimum_consent_level=explicit'
+      expect(subject.identity.subscription_status_path('abc123', opt_in_external_id: 'policy-1.5', minimum_consent_level: 'explicit')).to eq expected_path
+    end
   end
 end


### PR DESCRIPTION
This updates the `identity.subscription_status_path` method to support the optional `minimum_consent_level` parameter.

Depends on https://github.com/controlshift/tokyo/pull/36