### PR TITLE
Accept encrypted param for Identity

### DIFF
--- a/lib/tokyo_api/identity.rb
+++ b/lib/tokyo_api/identity.rb
@@ -8,7 +8,7 @@ module TokyoApi
       client.get_request("#{normalized_base_path}full_user/#{url_escape(id)}").body
     end
 
-    def tokyo_identity_user_path(id, with_subscription_status: false, required_fields: nil, opt_in_public_ids: nil, minimum_consent_level: nil)
+    def tokyo_identity_user_path(id, with_subscription_status: false, required_fields: nil, opt_in_public_ids: nil, minimum_consent_level: nil, encrypted: nil)
       path = "/#{normalized_base_path}user/#{url_escape(id)}"
 
       params = []
@@ -24,6 +24,10 @@ module TokyoApi
         end
       end
 
+      if encrypted
+        params << 'encrypted=1'
+      end
+
       if params.any?
         path << "?#{params.join('&')}"
       end
@@ -31,15 +35,20 @@ module TokyoApi
       path
     end
 
-    def subscription_status_path(id, opt_in_public_ids: nil, minimum_consent_level: nil)
+    def subscription_status_path(id, opt_in_public_ids: nil, minimum_consent_level: nil, encrypted: nil)
       raise 'must provide opt_in_public_ids' if opt_in_public_ids.nil?
 
-      "/#{normalized_base_path}subscription_status/#{url_escape(id)}?#{path_for_subscription_status_params(opt_in_public_ids, minimum_consent_level)}"
+      path = "/#{normalized_base_path}subscription_status/#{url_escape(id)}?#{path_for_subscription_status_params(opt_in_public_ids, minimum_consent_level)}"
+      if encrypted
+        path << '&encrypted=1'
+      end
+
+      path
     end
 
     private
 
-    def path_for_subscription_status_params(opt_in_public_ids, minimum_consent_level)
+    def path_for_subscription_status_params(opt_in_public_ids, minimum_consent_level, encrypted = nil)
       path = ''
 
       if opt_in_public_ids.present?
@@ -48,6 +57,10 @@ module TokyoApi
 
       if minimum_consent_level
         path << "&minimum_consent_level=#{url_escape(minimum_consent_level)}"
+      end
+
+      if encrypted
+        path << "&encrypted=#{encrypted}"
       end
 
       path

--- a/lib/tokyo_api/identity.rb
+++ b/lib/tokyo_api/identity.rb
@@ -18,14 +18,10 @@ module TokyoApi
 
       if with_subscription_status
         params << 'with_subscription_status=true'
-        additional_subscription_parameters = path_for_subscription_status_params(opt_in_public_ids, minimum_consent_level)
+        additional_subscription_parameters = path_for_subscription_status_params(opt_in_public_ids, minimum_consent_level, encrypted)
         unless additional_subscription_parameters.blank?
           params << additional_subscription_parameters
         end
-      end
-
-      if encrypted
-        params << 'encrypted=1'
       end
 
       if params.any?
@@ -38,12 +34,7 @@ module TokyoApi
     def subscription_status_path(id, opt_in_public_ids: nil, minimum_consent_level: nil, encrypted: nil)
       raise 'must provide opt_in_public_ids' if opt_in_public_ids.nil?
 
-      path = "/#{normalized_base_path}subscription_status/#{url_escape(id)}?#{path_for_subscription_status_params(opt_in_public_ids, minimum_consent_level)}"
-      if encrypted
-        path << '&encrypted=1'
-      end
-
-      path
+      "/#{normalized_base_path}subscription_status/#{url_escape(id)}?#{path_for_subscription_status_params(opt_in_public_ids, minimum_consent_level, encrypted)}"
     end
 
     private
@@ -60,7 +51,7 @@ module TokyoApi
       end
 
       if encrypted
-        path << "&encrypted=#{encrypted}"
+        path << "&encrypted=1"
       end
 
       path

--- a/spec/identity_spec.rb
+++ b/spec/identity_spec.rb
@@ -77,6 +77,10 @@ describe TokyoApi::Identity do
         expect(subject.identity.tokyo_identity_user_path('123abc456', with_subscription_status: true)).to match /.+with_subscription_status=.+/
       end
 
+      it 'should include encrypted parameter if argument is true' do
+        expect(subject.identity.tokyo_identity_user_path('123abc456', with_subscription_status: true, encrypted: true)).to match /.+encrypted=.+/
+      end
+
       it 'should include opt_in_public_ids and minimum_consent_level if with_subscription_status is true' do
         tokyo_path = subject.identity.tokyo_identity_user_path('123abc456',
                                                                 required_fields: [:first_name, :last_name, :email, :postal, :phone],
@@ -105,6 +109,11 @@ describe TokyoApi::Identity do
     it 'should support minimum_consent_level' do
       expected_path = '/identity/subscription_status/abc123?opt_in_public_ids=policy-1.5&minimum_consent_level=explicit'
       expect(subject.identity.subscription_status_path('abc123', opt_in_public_ids: ['policy-1.5'], minimum_consent_level: 'explicit')).to eq expected_path
+    end
+
+    it 'should support encrypted param' do
+      expected_path = '/identity/subscription_status/abc123?opt_in_public_ids=policy-1.5&minimum_consent_level=explicit&encrypted=1'
+      expect(subject.identity.subscription_status_path('abc123', opt_in_public_ids: ['policy-1.5'], minimum_consent_level: 'explicit', encrypted: true)).to eq expected_path
     end
   end
 end


### PR DESCRIPTION
This is part of the change to allow Agra to get details from Identity using the email address. It adds support for the client telling Tokyo that the identifier parameter is encrypted.