### PR TITLE
Allow specifying a default timeout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source "http://rubygems.org"
 
-#gem 'vertebrae', '~> 0.5.0'
-gem 'vertebrae', git: 'https://github.com/controlshift/vertebrae.git', branch: 'connection-options'
+gem 'vertebrae', '~> 0.5.1'
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "http://rubygems.org"
 
-gem 'vertebrae', '~> 0.5.0'
+#gem 'vertebrae', '~> 0.5.0'
+gem 'vertebrae', git: 'https://github.com/controlshift/vertebrae.git', branch: 'connection-options'
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A ruby gem for communicating with ControlShift's Tokyo API.
 ## Usage
 
 ```ruby
-ta = TokyoApi.new(host: 'localhost:9000', username: 'tokyo', password: 'Passw0rd!', scheme: 'http')
+ta = TokyoApi.new(host: 'localhost:9000', username: 'tokyo', password: 'Passw0rd!', scheme: 'http', timeout: 5)
 ta.organisation.expire('foo.com')
 ```
 

--- a/lib/tokyo_api/client.rb
+++ b/lib/tokyo_api/client.rb
@@ -26,11 +26,17 @@ module TokyoApi
 
 
     def default_options
-      {
+      opts = {
         user_agent: 'TokyoApi Gem',
         prefix: '',
         content_type: 'application/json'
       }
+
+      if initialisation_options.has_key?(:timeout)
+        opts[:connection_options] = {request: {timeout: initialisation_options[:timeout]}}
+      end
+
+      opts
     end
 
     def request(method, path, params, options) # :nodoc:

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,16 +1,26 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe TokyoApi::Client do
-
-  describe "instantiated" do
+  describe 'initialization' do
     subject { described_class.new(options) }
 
-    context 'process_basic_auth' do
-      let(:options) { { :basic_auth => 'login:password' } }
-      let(:config) { subject.connection.configuration  }
-      specify { expect(config.username).to eq 'login' }
-      specify { expect(config.password).to eq 'password' }
+    context 'with a basic_auth string parameter' do
+      let(:options) { {basic_auth: 'login:password'} }
+
+      it 'should set username/password on the configuration' do
+        config = subject.connection.configuration
+        expect(config.username).to eq 'login'
+        expect(config.password).to eq 'password'
+      end
     end
 
+    context 'with a timeout' do
+      let(:options) { {timeout: 5} }
+
+      it 'should set the timeout on the faraday options' do
+        config = subject.connection.configuration
+        expect(config.faraday_options[:request][:timeout]).to eq 5
+      end
+    end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,7 +1,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe TokyoApi::Client do
-  describe 'initialization' do
+  describe 'initialisation' do
     subject { described_class.new(options) }
 
     context 'with a basic_auth string parameter' do


### PR DESCRIPTION
This allows a user to pass a `timeout` parameter when instantiating a client object, e.g. `TokyoApi.new(timeout: 5)`. We pass that timeout along in the appropriate way to set up the `Faraday::Connection`, so all requests will use the timeout specified.

Depends on https://github.com/controlshift/vertebrae/pull/3